### PR TITLE
Feature/incorporate code sprint time into ranking

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -240,7 +240,7 @@ a {
 
 .score__value {
   display: flex;
-  align-items: center;
+  align-items: right;
   color: var(--highscore-white-color);
 }
 
@@ -249,6 +249,12 @@ a {
 }
 
 .score__date {
+  font-size: 14px;
+  font-weight: 400;
+  font-style: italic;
+}
+
+.score__code_sprint_time {
   font-size: 14px;
   font-weight: 400;
   font-style: italic;

--- a/src/scores/Score.ts
+++ b/src/scores/Score.ts
@@ -34,6 +34,12 @@ export class Score {
   @Groups('read', 'create', 'update')
   public score: number;
 
+  // ?: Set to optional. If the player submits and incorrect Code Sprint solution, their code_sprint_time is set to zero.
+  @Required()
+  @Property()
+  @Groups('read', 'create', 'update')
+  public code_sprint_time: number;
+
   @Groups('read')
   public rank: number;
 

--- a/src/scores/ScoreService.ts
+++ b/src/scores/ScoreService.ts
@@ -30,7 +30,18 @@ export class ScoreService {
 
     query.push({
       $setWindowFields: {
-        sortBy: { value: -1 },
+        sortBy: { code_sprint_time: 1 },
+        output: {
+          rank: {
+            $rank: {},
+          },
+        },
+      },
+    });
+
+    query.push({
+      $setWindowFields: {
+        sortBy: { score: -1 },
         output: {
           rank: {
             $rank: {},

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,54 +1,67 @@
 <%- include('./_includes/header'); -%>
-<main class="highscore__main">
-    <h3 class="highscore__leaderboard highscore__leaderboard--category">
-        leader<span>board</span>
-    </h3>
+    <main class="highscore__main">
+        <h3 class="highscore__leaderboard highscore__leaderboard--category">
+            leader<span>board</span>
+        </h3>
 
-    <% if (locals.category) { %>
-        <h4 class="highscore__category"><%= category %></h4>
-    <% } %>
+        <% if (locals.category) { %>
+            <h4 class="highscore__category">
+                <%= category %>
+            </h4>
+            <% } %>
 
-    <div class="highscore__scores">
-        <% scores.forEach((score, index) => { %>
-            <a class="score" href="/score/<%= score._id %>">
-                <div class="score__name">
-                    <div class="score__position"><%= score.rank %></div>
-                    <div class="score__info">
-                        <p><%= score.forename %> <%= score.surname %></p>
-                        <p class="score__date"><%= $day(score.createdAt).fromNow() %></p>
-                    </div>
+                <div class="highscore__scores">
+                    <% scores.forEach((score, index)=> { %>
+                        <a class="score" href="/score/<%= score._id %>">
+                            <div class="score__name">
+                                <div class="score__position">
+                                    <%= score.rank %>
+                                </div>
+                                <div class="score__info">
+                                    <p>
+                                        <%= score.forename %>
+                                            <%= score.surname %>
+                                    </p>
+                                    <p class="score__date">
+                                        Played <%= $day(score.createdAt).fromNow() %> ago
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="score__value">
+                                <div>
+                                    <p >
+                                        Scored <%= score.score %>
+                                    </p>
+                                    <p class="score__code_sprint_time">
+                                        Code Sprint completed in <%= score.code_sprint_time %> seconds
+                                    </p>
+                                </div>
+                            </div>
+                        </a>
+                        <% }) %>
+
+                            <% if (pages> 1) { %>
+                                <div class="pagination">
+                                    <a class="pagination__link" <% if (page> 1) { %>
+                                        href="/?page=<%= page - 1 %>
+                                            <%= locals.category ? `&category=${category}` : '' %>"
+                                                <% } %>
+                                                    >
+                                                    previous
+                                    </a>
+                                    <p class="pagination__page">
+                                        <%= page %> / <%= pages %>
+                                    </p>
+                                    <a class="pagination__link" <% if (page < pages) { %>
+                                        href="/?page=<%= page + 1 %>
+                                            <%= locals.category ? `&category=${category}` : '' %>"
+                                                <% } %>
+                                                    >
+                                                    next
+                                    </a>
+                                </div>
+                                <% } %>
                 </div>
-                <div class="score__value">
-                    <div><%= score.value %></div>
-                    <div></div>
-                </div>
-            </a>
-        <% }) %>
+    </main>
 
-        <% if (pages > 1) { %>
-            <div class="pagination">
-                <a 
-                    class="pagination__link" 
-                    <% if (page > 1) { %>  
-                        href="/?page=<%= page - 1 %><%= locals.category ? `&category=${category}` : '' %>"
-                    <% } %>
-                >
-                    previous
-                </a>
-                <p class="pagination__page">
-                    <%= page %> / <%= pages %>
-                </p>
-                <a 
-                    class="pagination__link" 
-                    <% if (page < pages) { %> 
-                        href="/?page=<%= page + 1 %><%= locals.category ? `&category=${category}` : '' %>"
-                    <% } %>
-                >
-                    next
-                </a>
-            </div>
-        <% } %>
-    </div>
-</main>
-
-<%- include('./_includes/footer'); -%>
+    <%- include('./_includes/footer'); -%>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,7 +23,7 @@
                                             <%= score.surname %>
                                     </p>
                                     <p class="score__date">
-                                        Played <%= $day(score.createdAt).fromNow() %> ago
+                                        Played <%= $day(score.createdAt).fromNow() %>
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
This PR adds a property along with styling and formatting for the Code Sprint time in seconds. The MongoDB aggregation query has also been updated to sort on the Code Sprint Time first and then the score for each player. This additional sorting addresses the scenario where two or more players achieve the same score but differing Code Sprint times. Of course, if they achieve the same score and the same Code Sprint time, they'll have to fight to the death for those AirPods 😋 